### PR TITLE
Added SRILM to the installation scripts

### DIFF
--- a/install/install-dependencies2.sh
+++ b/install/install-dependencies2.sh
@@ -31,6 +31,10 @@ apt-get -yq install imagemagick graphviz
 # Perl library needed for NIST BLEU
 /opt/casmacat/install/cpanm XML::Twig
 
+# dependencies for srilm
+#echo 'STEP 7.secret/9: installing software for srilm '`date +%s`
+#apt-get install tcl tcl-dev csh gawk
+
 # needed for thot / itp server
 echo 'STEP 8/9: installing software for thot '`date +%s`
 apt-get -yq install libtool pkg-config autoconf-archive swig python-dev libperl-dev

--- a/install/install-dependencies2.sh
+++ b/install/install-dependencies2.sh
@@ -32,7 +32,7 @@ apt-get -yq install imagemagick graphviz
 /opt/casmacat/install/cpanm XML::Twig
 
 # dependencies for srilm
-#echo 'STEP 7.secret/9: installing software for srilm '`date +%s`
+#echo 'STEP 7.srilm/9: installing software for srilm '`date +%s`
 #apt-get install tcl tcl-dev csh gawk
 
 # needed for thot / itp server

--- a/install/install-moses.sh
+++ b/install/install-moses.sh
@@ -86,6 +86,20 @@ fi
 #./configure
 #make -j8
 
+# SRILM
+#echo 'STEP 5.srilm: installing srilm'`date +%s`
+#mkdir -p /opt/moses/external/srilm
+#mkdir /opt/moses/external/bin/srilm
+#cd /opt/moses/external/srilm
+#if [ ! -d srilm-1.7.1]
+#then
+#  wget https://moses-suite.googlecode.com/files/srilm-1.7.1.tar.gz
+#  tar xzf srilm-1.7.1.tar.gz
+#  sed -i '8i\SRILM=/opt/moses/external/srilm\' Makefile # inserts the path to the makefile the textfile
+#  make NO_TCL=1 MACHINE_TYPE=i686-ubuntu World
+#  cp bin/i686-ubuntu/ngram-count /opt/moses/external/bin/srilm/
+#fi
+
 # Moses
 echo 'STEP 6/7: compiling moses (may take a while) '`date +%s`
 cd /opt/moses

--- a/install/install-moses.sh
+++ b/install/install-moses.sh
@@ -91,7 +91,7 @@ fi
 #mkdir -p /opt/moses/external/srilm
 #mkdir /opt/moses/external/bin/srilm
 #cd /opt/moses/external/srilm
-#if [ ! -d srilm-1.7.1]
+#if [ ! -d srilm-1.7.1 ]
 #then
 #  wget https://db.tt/i1niluth # dropbox link to SRILM 1.7.1
 #  tar xzf srilm-1.7.1.tar.gz

--- a/install/install-moses.sh
+++ b/install/install-moses.sh
@@ -93,7 +93,7 @@ fi
 #cd /opt/moses/external/srilm
 #if [ ! -d srilm-1.7.1]
 #then
-#  wget https://moses-suite.googlecode.com/files/srilm-1.7.1.tar.gz
+#  wget https://db.tt/i1niluth # dropbox link to SRILM 1.7.1
 #  tar xzf srilm-1.7.1.tar.gz
 #  sed -i '8i\SRILM=/opt/moses/external/srilm\' Makefile # inserts the path to the makefile the textfile
 #  make NO_TCL=1 MACHINE_TYPE=i686-ubuntu World


### PR DESCRIPTION
Thank you for these installation scripts, they were very helpful in resolving installation issues for Moses and Casmacat.

It's not that easy for people to install SRILM if they have not chanced upon Spence Green blog page: http://www.spencegreen.com/2012/02/01/installing-srilm-on-ubuntu-11-10/. So i've added some commented lines to the installation scripts you have for Casmascat.

I've modified the commands he gave a little and automate the process to suit the installation of moses in `/opt/moses/`. Although I don't use SRILM, there are people who asks questions on how to install SRILM in ubuntu so maybe the added lines in the installation will somehow help the someone in need someday.
